### PR TITLE
Fix CPU execution with NOP instructions

### DIFF
--- a/instrucciones.py
+++ b/instrucciones.py
@@ -27,6 +27,11 @@ class CPU:
             self.mem = memoria_externa
 
         bit_length = instruccion.bit_length()
+        if bit_length == 0:
+            # Para instrucciones como NOP (0x00) cuyo bit_length es 0,
+            # consideramos un tamaño mínimo de 8 bits para evitar errores
+            bit_length = 8
+
         self.instrucciones.ejecutar(instruccion, bit_length)
 
 class Instrucciones:


### PR DESCRIPTION
## Summary
- ensure CPU treats `NOP` (0x00) as an 8‑bit instruction

## Testing
- `python - <<'EOF'
from assembler import assemble_lines
from cpu_core import run_instructions
lines=["LOADK R0, 25", "LOADK R1, 0", "NOP", "NOP", "NOP", "NOP", "NOP", "HALT"]
compiled = assemble_lines(lines)
print("compiled:", compiled)
cpu, mem = run_instructions(compiled)
print("regs", cpu.reg[:2])
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688050d73afc83259a2ab139beffceba